### PR TITLE
Solving the 'StopIteration' error when using multi-GPUs with PyTorch >= 1.5, CUDA>=11.0

### DIFF
--- a/src/transformers/modeling_bert.py
+++ b/src/transformers/modeling_bert.py
@@ -712,38 +712,42 @@ class BertModel(BertPreTrainedModel):
         if token_type_ids is None:
             token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
 
+#        # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
+#        # ourselves in which case we just need to make it broadcastable to all heads.
+#        if attention_mask.dim() == 3:
+#            extended_attention_mask = attention_mask[:, None, :, :]
+#        elif attention_mask.dim() == 2:
+#            # Provided a padding mask of dimensions [batch_size, seq_length]
+#            # - if the model is a decoder, apply a causal mask in addition to the padding mask
+#            # - if the model is an encoder, make the mask broadcastable to [batch_size, num_heads, seq_length, seq_length]
+#            if self.config.is_decoder:
+#                batch_size, seq_length = input_shape
+#                seq_ids = torch.arange(seq_length, device=device)
+#                causal_mask = seq_ids[None, None, :].repeat(batch_size, seq_length, 1) <= seq_ids[None, :, None]
+#                causal_mask = causal_mask.to(
+#                    attention_mask.dtype
+#                )  # causal and attention masks must have same type with pytorch version < 1.3
+#                extended_attention_mask = causal_mask[:, None, :, :] * attention_mask[:, None, None, :]
+#            else:
+#                extended_attention_mask = attention_mask[:, None, None, :]
+#        else:
+#            raise ValueError(
+#                "Wrong shape for input_ids (shape {}) or attention_mask (shape {})".format(
+#                    input_shape, attention_mask.shape
+#                )
+#            )
+#
+#        # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
+#        # masked positions, this operation will create a tensor which is 0.0 for
+#        # positions we want to attend and -10000.0 for masked positions.
+#        # Since we are adding it to the raw scores before the softmax, this is
+#        # effectively the same as removing these entirely.
+#        extended_attention_mask = extended_attention_mask.to(dtype=next(self.parameters()).dtype)  # fp16 compatibility
+#        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+
         # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
         # ourselves in which case we just need to make it broadcastable to all heads.
-        if attention_mask.dim() == 3:
-            extended_attention_mask = attention_mask[:, None, :, :]
-        elif attention_mask.dim() == 2:
-            # Provided a padding mask of dimensions [batch_size, seq_length]
-            # - if the model is a decoder, apply a causal mask in addition to the padding mask
-            # - if the model is an encoder, make the mask broadcastable to [batch_size, num_heads, seq_length, seq_length]
-            if self.config.is_decoder:
-                batch_size, seq_length = input_shape
-                seq_ids = torch.arange(seq_length, device=device)
-                causal_mask = seq_ids[None, None, :].repeat(batch_size, seq_length, 1) <= seq_ids[None, :, None]
-                causal_mask = causal_mask.to(
-                    attention_mask.dtype
-                )  # causal and attention masks must have same type with pytorch version < 1.3
-                extended_attention_mask = causal_mask[:, None, :, :] * attention_mask[:, None, None, :]
-            else:
-                extended_attention_mask = attention_mask[:, None, None, :]
-        else:
-            raise ValueError(
-                "Wrong shape for input_ids (shape {}) or attention_mask (shape {})".format(
-                    input_shape, attention_mask.shape
-                )
-            )
-
-        # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
-        # masked positions, this operation will create a tensor which is 0.0 for
-        # positions we want to attend and -10000.0 for masked positions.
-        # Since we are adding it to the raw scores before the softmax, this is
-        # effectively the same as removing these entirely.
-        extended_attention_mask = extended_attention_mask.to(dtype=next(self.parameters()).dtype)  # fp16 compatibility
-        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+        extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(attention_mask, input_shape, device)
 
         # If a 2D ou 3D attention mask is provided for the cross-attention
         # we need to make broadcastabe to [batch_size, num_heads, seq_length, seq_length]
@@ -752,43 +756,47 @@ class BertModel(BertPreTrainedModel):
             encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
             if encoder_attention_mask is None:
                 encoder_attention_mask = torch.ones(encoder_hidden_shape, device=device)
+            encoder_extened_attention_mask = self.invert_attention_mask(encoder_attention_mask)
 
-            if encoder_attention_mask.dim() == 3:
-                encoder_extended_attention_mask = encoder_attention_mask[:, None, :, :]
-            elif encoder_attention_mask.dim() == 2:
-                encoder_extended_attention_mask = encoder_attention_mask[:, None, None, :]
-            else:
-                raise ValueError(
-                    "Wrong shape for encoder_hidden_shape (shape {}) or encoder_attention_mask (shape {})".format(
-                        encoder_hidden_shape, encoder_attention_mask.shape
-                    )
-                )
-
-            encoder_extended_attention_mask = encoder_extended_attention_mask.to(
-                dtype=next(self.parameters()).dtype
-            )  # fp16 compatibility
-            encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -10000.0
+#            if encoder_attention_mask.dim() == 3:
+#                encoder_extended_attention_mask = encoder_attention_mask[:, None, :, :]
+#            elif encoder_attention_mask.dim() == 2:
+#                encoder_extended_attention_mask = encoder_attention_mask[:, None, None, :]
+#            else:
+#                raise ValueError(
+#                    "Wrong shape for encoder_hidden_shape (shape {}) or encoder_attention_mask (shape {})".format(
+#                        encoder_hidden_shape, encoder_attention_mask.shape
+#                    )
+#                )
+#
+#            encoder_extended_attention_mask = encoder_extended_attention_mask.to(
+#                dtype=next(self.parameters()).dtype
+#            )  # fp16 compatibility
+#            encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -10000.0
         else:
             encoder_extended_attention_mask = None
+
 
         # Prepare head mask if needed
         # 1.0 in head_mask indicate we keep the head
         # attention_probs has shape bsz x n_heads x N x N
         # input head_mask has shape [num_heads] or [num_hidden_layers x num_heads]
         # and head_mask is converted to shape [num_hidden_layers x batch x num_heads x seq_length x seq_length]
-        if head_mask is not None:
-            if head_mask.dim() == 1:
-                head_mask = head_mask.unsqueeze(0).unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
-                head_mask = head_mask.expand(self.config.num_hidden_layers, -1, -1, -1, -1)
-            elif head_mask.dim() == 2:
-                head_mask = (
-                    head_mask.unsqueeze(1).unsqueeze(-1).unsqueeze(-1)
-                )  # We can specify head_mask for each layer
-            head_mask = head_mask.to(
-                dtype=next(self.parameters()).dtype
-            )  # switch to fload if need + fp16 compatibility
-        else:
-            head_mask = [None] * self.config.num_hidden_layers
+        head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
+
+#        if head_mask is not None:
+#            if head_mask.dim() == 1:
+#                head_mask = head_mask.unsqueeze(0).unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+#                head_mask = head_mask.expand(self.config.num_hidden_layers, -1, -1, -1, -1)
+#            elif head_mask.dim() == 2:
+#                head_mask = (
+#                    head_mask.unsqueeze(1).unsqueeze(-1).unsqueeze(-1)
+#                )  # We can specify head_mask for each layer
+#            head_mask = head_mask.to(
+#                dtype=next(self.parameters()).dtype
+#            )  # switch to fload if need + fp16 compatibility
+#        else:
+#            head_mask = [None] * self.config.num_hidden_layers
 
         embedding_output = self.embeddings(
             input_ids=input_ids, position_ids=position_ids, token_type_ids=token_type_ids, inputs_embeds=inputs_embeds

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -19,9 +19,10 @@
 import logging
 import os
 import typing
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import torch
-from torch import nn
+from torch import Tensor, device, dtype, nn
 from torch.nn import CrossEntropyLoss
 from torch.nn import functional as F
 
@@ -36,7 +37,6 @@ from .file_utils import (
     hf_bucket_url,
     is_remote_url,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -54,19 +54,203 @@ except ImportError:
         def forward(self, input):
             return input
 
+def get_parameter_device(parameter: Union[nn.Module, "ModuleUtilsMixin"]):
+    try:
+        return next(parameter.parameters()).device
+    except StopIteration:
+        # For nn.DataParallel compatibility in PyTorch 1.5
+
+        def find_tensor_attributes(module: nn.Module) -> List[Tuple[str, Tensor]]:
+            tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
+            return tuples
+
+        gen = parameters._named_members(get_members_fn=find_tensor_attributes)
+        first_tuple = next(get)
+        return first_tuple[1].device
+
+def get_parameter_dtype(parameter: Union[nn.Module, "ModuleUtilisMixin"]):
+    try:
+        return next(parameter.parameters()).dtype
+    except StopIteration:
+        # For nn.DataParallel compatibility in PyTorch 1.5
+
+        def find_tensor_attributes(module: nn.Module) -> List[Tuple[str, Tensor]]:
+            tuples = [(k, v) for k, v in module.__dict__.items() if torch.is_tensor(v)]
+            return tuples
+
+        gen = parameter._named_members(get_members_fn=find_tensor_attributes)
+        first_tuple = next(gen)
+        return first_tuple[1].dtype
 
 class ModuleUtilsMixin:
     """
     A few utilities for torch.nn.Modules, to be used as a mixin.
     """
 
-    def num_parameters(self, only_trainable: bool = False) -> int:
+    @property
+    def device(self) -> device:
         """
-        Get number of (optionally, trainable) parameters in the module.
+        :obj:'torch.device': The device on which the module is (assuming that all the module parameters are on the same device).
         """
-        params = filter(lambda x: x.requires_grad, self.parameters()) if only_trainable else self.parameters()
-        return sum(p.numel() for p in params)
+        return get_parameter_device(self)
 
+    @property
+    def dtype(self) -> dtype:
+        """
+        :obj:'torch.dtype': The dtype of the module (assuming that all the module parameters have the same dtype).
+        """
+        return get_parameter_dtype(self)
+
+    def invert_attention_mask(self, encoder_attention_mask: Tensor) -> Tensor:
+        """
+        Invert an attention mask (e.g., switches 0. and 1.).
+
+        Args:
+            encoder_attention_mask (:obj:'torch.Tensor'): An attention mask.
+
+        Returns:
+            :obj:'torch.Tensor': The inverted attention mask.
+        """
+        if encoder_attention_mask.dim() == 3:
+            encoder_extended_attention_mask = encoder_attention_mask[:, None, :, :]
+        if encoder_attention_mask.dim() == 2:
+            encoder_extended_attentino_mask = encoder_attention_mask[:, None, None, :]
+        # T5 has a mask that can compare sequence ids, we can simulate this here with this transposition
+        # CF. https://github.com/tensorflow/mesh/blob/8d2465e9bc93129b913b5ccc6a59aa97abd96ec6/mesh_tensorflow
+        # /transformer/transformer_layers.py#L270
+        # encoder_extended_attention_mask = (encoder_extended_attention_mask ==
+        # encoder_extended_attention_mask.transpose(-1, 02))
+        encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype) # fp16 compatibility
+
+        if self.dtype == torch.float16:
+            encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -1e4
+        elif self.dtype == torch.float32:
+            encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * -1e9
+        else:
+            raise ValueError(
+                f"{self.dtype} not recofnized. 'dtype' should be set to either 'torch.float32' or 'torch.float16'"
+            )
+
+        return encoder_extended_attention_mask
+
+    def get_extended_attention_mask(self, attention_mask: Tensor, input_shape: Tuple[int], device: device) -> Tensor:
+        """
+        Makes broadcastable attention and causal masks so that future and masked tokens are ignored.
+
+        Arguments:
+            attention_mask (:obj:'torch.Tensor'):
+                Mask with ones indicating tokens to attend to, zeros for tokens to ignore.
+            input_shape (:obj:'Tuple[int]'):
+                The shape of the input to the model.
+            device: (:obj:'torch.device'):
+                The device of the input to the model.
+
+        Returns:
+            :obj:'torch.Tensor' The extended attention mask, with a the same dtype as 'obj':'attention_mask.dtype'.
+        """
+        # We can provide a self-attention mask of dimentions [batch_size, from_seq_length, to_seq_length]
+        # ourselves in which case we just need to make it broadcastable to all heads.
+        if attention_mask.dim() == 3:
+            extended_attention_mask = attention_mask[:, None, :, :]
+        elif attention_mask.dim() == 2:
+            # Provided a padding mask of dimensions [batch_size, seq_length]
+            # - if the model is a decoder, apply a causal mask in additino to the padding mask
+            # - if the model is an encoder, make the mask broadcastable to [batch_size, num_heads, seq_length, seq_length]
+            if self.config.is_decoder:
+                batch_size, seq_length = input_shape
+                seq_ids = torch.arange(seq_length, device=device)
+                causal_mask = seq_ids[None, None, :].repeat(batch_size, seq_length, 1) <= seq_ids[None, :, None]
+                # in case past_key_values are used we need to add a prefix ones mask to the causal mask
+                # causal and attention masks must have same type with pytorch version < 1.3
+                causal_mask = causal_mask.to(attention_mask.dtype)
+
+                if causal_mask.shape[1] < attention_mask.shape[1]:
+                    prefix_seq_len = attention_mask.shape[1] - causal_mask.shape[1]
+                    causal_mask = torch.cat(
+                        [
+                            torch.ones(
+                                (batch_size, seq_length, prefix_seq_len), device=device, dtype=causal_mask.dtype
+                            ),
+                            causal_mask,
+                        ],
+                        axis=-1,
+                    )
+
+                extended_attention_mask = causal_mask[:, None, :, :] * attention_mask[:, None, None, :]
+            else:
+                extended_attention_mask = attention_mask[:, None, None, :]
+        else:
+            raise ValueError(
+                f"Wrong shape for input_ids (shape {input_shape}) or attention_mask (shape {attention_mask.shape})"
+            )
+
+        # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
+        # masked positions, this operation will create a tensor which is 0.0 for
+        # positions we want to attend and -10000.0 for masked positions.
+        # Since we are adding it to the raw scores before the softmax, this is
+        # effectively the same as removing these entirely.
+        exteneded_attention_mask = extended_attention_mask.to(dtype=self.dtype)
+        exteneded_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+        return extended_attention_mask
+
+    def get_head_mask(
+        self, head_mask: Optional[Tensor], num_hidden_layers: int, is_attention_chunked: bool = False
+    ) -> Tensor:
+        """
+        Prepare the head mask if needed.
+
+        Args:
+            head_mask (:obj:'torch.Tensor' with shape :obj:'[num_heads]' or :obj:'[num_hidden_layers x num_heads]', 'optional'):
+                The mask indicating if we should keep the heads or not (1.0 for keep, 0.0 for discard).
+            num_hidden_layers (:obj:'int'):
+                The number of hidden layers in the model.
+            is_attention_chunked: (:obj:'bool', 'optional', defaults to :obj:'False'):
+                Whether or not the attentions scores are computed by chunks or not.
+
+        Returns:
+            :obj:'torch.Tensor' with shape :obj:'[num_hidden_layers x batch x num_heads x seq_length]' or
+            list with :obj:'[None]' for each layer.
+        """
+        if head_mask is not None:
+            head_mask = self._convert_head_mask_to_5d(head_mask, num_hidden_layers)
+            if is_attention_chunked is True:
+                head_mask = head_mask.unsqueeze(-1)
+        else:
+            head_mask = [None] * num_hidden_layers
+
+        return head_mask
+
+    def _convert_head_mask_to_5d(self, head_mask, num_hidden_layers):
+        """-> [num_hidden_layers x batch x num_heads x seq_length x seq_length]"""
+        if head_mask.dim() == 1:
+            head_mask = head_mask.unsqueeze(0).unsqueeze(0).unsqueeze(-1).unsqueeze(-1)
+            head_mask = head_mask.expand(num_hidden_layers, -1, -1, -1, -1)
+        elif head_mask.dim() == 2:
+            head_mask = head_mask.unsqueeze(1).unsqueeze(-1).unsqueeze(-1) # We can specify head_mask for each layer
+        assert head_mask.dim() == 5, f"head_mask.dim != 5, instead {head_mask.dim()}"
+        head_mask = head_mask.to(dtype=self.dtype) # switch to float if need + fp16 compatibility
+        return head_mask
+
+    def num_parameters(self, only_trainable: bool = False, exclude_embeddings: bool = False) -> int:
+        """
+        Get number of (optionally, trainable) or non-embeddings parameters in the module.
+
+        Args:
+            only_trainable (:obj:'bool', 'optional', defaults to :obj:'False'):
+                Whether or not ro return only the number of trainable parameters
+
+            exclude_embeddings (:obj:'bool', 'optional', defaults to :obj:'False'):
+                Whether or not to return only the number of non-embeddings parameters
+
+        Returns:
+           :obj:'int': The number of parameters.
+        """
+
+        def parameter_filter(x):
+            return (x.requires_grad or not only_trainable) and not (isinstance(x, nn.Embedding) and exclude_embeddings) 
+
+        params = filter(parameter_filter, self.parameters()) if only_trainable else self.parameters()
+        return sum(p.numel() for p in params)
 
 class PreTrainedModel(nn.Module, ModuleUtilsMixin):
     r""" Base class for all models.


### PR DESCRIPTION
Based on the current version of transformers used in DNABERT (v2.5),
StopIteration error occurs when using multi-GPUs with PyTorch >= 1.5, CUDA >= 11.0
#19 

Although this error can be prevented by using the older version of PyTorch and CUDA,
many GPU machines require a higher version of CUDA
(e.g. A100 GPU requires CUDA >= 11.0)

This ISSUE is already solved in the latest version of transformers
(https://github.com/huggingface/transformers/pull/4300)

Based on the latest version of transformers
I modified modeling_bert.py and modeling_utils.py in src/transformer/

With this modified version, no more error occurs when using multi-GPUs with PyTorch >= 1.5, CUDA > 11.0 