### PR TITLE
Fix typo in modeling_utils.py

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -189,8 +189,8 @@ class ModuleUtilsMixin:
         # positions we want to attend and -10000.0 for masked positions.
         # Since we are adding it to the raw scores before the softmax, this is
         # effectively the same as removing these entirely.
-        exteneded_attention_mask = extended_attention_mask.to(dtype=self.dtype)
-        exteneded_attention_mask = (1.0 - extended_attention_mask) * -10000.0
+        extended_attention_mask = extended_attention_mask.to(dtype=self.dtype)
+        extended_attention_mask = (1.0 - extended_attention_mask) * -10000.0
         return extended_attention_mask
 
     def get_head_mask(


### PR DESCRIPTION
Fix typos in modeling_utils.py to return the correct attention masks.